### PR TITLE
Allow --em in console

### DIFF
--- a/Command/SlugCommand.php
+++ b/Command/SlugCommand.php
@@ -79,4 +79,5 @@ class SlugCommand extends ContainerAwareCommand
         
         $output->writeln("\nDone!\n");
     }
+
 }

--- a/Command/SlugCommand.php
+++ b/Command/SlugCommand.php
@@ -26,12 +26,15 @@ class SlugCommand extends ContainerAwareCommand
                 InputArgument::OPTIONAL,
                 'Who do you want to greet?'
             )
+            ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $em = $this->getContainer()->get('doctrine')->getManager();
+        $doctrine = $this->getContainer()->get('doctrine');
+        $em = $doctrine->getManager($input->getOption('em'));
+        
         $helper = $this->getHelper('question');
         
         $output->writeln("\n<question>                                      ");
@@ -69,7 +72,9 @@ class SlugCommand extends ContainerAwareCommand
         $slugupdater = new SlugUpdater();
 
         foreach($entities as $entity)
-        {
+        {            blog:
+                driver:   pdo_mysql
+                options:
             $slugupdater->preUpdate(new LifecycleEventArgs($entity, $em));
             $em->flush();
         }

--- a/Command/SlugCommand.php
+++ b/Command/SlugCommand.php
@@ -72,9 +72,7 @@ class SlugCommand extends ContainerAwareCommand
         $slugupdater = new SlugUpdater();
 
         foreach($entities as $entity)
-        {            blog:
-                driver:   pdo_mysql
-                options:
+        {
             $slugupdater->preUpdate(new LifecycleEventArgs($entity, $em));
             $em->flush();
         }


### PR DESCRIPTION
Add --em as option

In order to be able to run generation of slugs on different em's please allow this tested change, run it with:
app/console fbeen:generate:slugs --em=default --env=YUORENV
app/console fbeen:generate:slugs --em=blog --env=YUORENV

in config you may have:
doctrine:
    dbal:
....
        default_connection: default
        connections:
            default:
                driver:   pdo_mysql
                options:
......
            blog:
                driver:   pdo_mysql
                options: