### PR TITLE
Allow config parameter to keep or remove specific language chars

### DIFF
--- a/Command/SlugCommand.php
+++ b/Command/SlugCommand.php
@@ -34,21 +34,21 @@ class SlugCommand extends ContainerAwareCommand
     {
         $doctrine = $this->getContainer()->get('doctrine');
         $em = $doctrine->getManager($input->getOption('em'));
-        
+
         $helper = $this->getHelper('question');
-        
+
         $output->writeln("\n<question>                                      ");
         $output->writeln(' Welcome to the Fbeen slug generator. ');
         $output->writeln("                                      </question>\n");
-        
+
         $entityName = $input->getArgument('entity');
-        
+
         if(!$entityName)
         {
             $output->writeln('This command helps you to update slugs on an entire table.');
             $output->writeln('First, you need to give the entity for which you want to generate the slugs.');
             $output->writeln("\nYou must use the shortcut notation like <comment>AcmeBlogBundle:Post</comment>.\n");
-            
+
             $question = new Question('<info>The Entity shortcut name: </info>');
 
             $question->setValidator(array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateEntityName'));
@@ -58,9 +58,9 @@ class SlugCommand extends ContainerAwareCommand
             $entityName = $helper->ask($input, $output, $question);
 
         }
-        
+
         $entities = $em->getRepository($entityName)->findAll();
-        
+
         $question = new ConfirmationQuestion('<info>Continue generating slugs for ' . $entityName . '</info> [<comment>no</comment>]? ', false);
 
         if (!$helper->ask($input, $output, $question)) {
@@ -68,15 +68,16 @@ class SlugCommand extends ContainerAwareCommand
         }
 
         $output->writeln("\nGenerating the slugs...");
-        
-        $slugupdater = new SlugUpdater();
+
+        $transliterate = $this->getContainer()->getParameter("transliterate", 'remove');
+        $slugupdater = new SlugUpdater($transliterate);
 
         foreach($entities as $entity)
         {
             $slugupdater->preUpdate(new LifecycleEventArgs($entity, $em));
             $em->flush();
         }
-        
+
         $output->writeln("\nDone!\n");
     }
 

--- a/Custom/Slugifier.php
+++ b/Custom/Slugifier.php
@@ -24,10 +24,10 @@ class Slugifier
         $this->entityManager = $entityManager;
         $this->additionalChars = $additionalChars;
     }
-    
-    public function generateSlug($text, $oldSlug = NULL)
+
+    public function generateSlug($text, $oldSlug = NULL, $transliterate)
     {
-        return $this->makeSlugUnique( $this->truncateSlug( $this->Slugify($text) ), $oldSlug );;
+        return $this->makeSlugUnique( $this->truncateSlug( $this->Slugify($text, $transliterate) ), $oldSlug );;
     }
 
     private function truncateSlug($slug)
@@ -35,39 +35,39 @@ class Slugifier
         // truncate slug to fieldlength - $additionalChars positions for additional number.
         if(strlen($slug) > $this->fieldlength - $this->additionalChars)
             return substr($slug, 0, $this->fieldlength - $this->additionalChars);
-        
+
         return $slug;
     }
-    
+
     private function makeSlugUnique($slug, $oldSlug)
     {
         $i = 0;
         $baseSlug = $slug;
         // SELECT * FROM `article` WHERE slug REGEXP '^nice-slug-[0-9]' OR slug='nice-slug'
-        $query = "SELECT " . $this->columnName . " FROM " . $this->tableName . 
+        $query = "SELECT " . $this->columnName . " FROM " . $this->tableName .
                  " WHERE " . $this->columnName . "='" . $slug . "'" .
                  " OR " . $this->columnName . " REGEXP '^" . $slug . "-[0-9]'";
 
         $statement = $this->entityManager->getConnection()->prepare($query);
         $statement->execute();
         $results = $statement->fetchAll();
-        
+
         // if the old slug (before the update) is in the results then we keep the same slug
         if($this->existSlug($oldSlug, $results))
         {
             return $oldSlug;
         }
-        
+
         // now find a new unique slug
         while($this->existSlug($slug, $results))
         {
             $i++;
             $slug = $baseSlug . '-' . $i;
         }
-        
+
         return $slug;
     }
-    
+
     private function existSlug($slug, $results)
     {
         foreach($results as $row)
@@ -75,11 +75,11 @@ class Slugifier
             if($row[$this->columnName] == $slug)
                 return TRUE;
         }
-        
+
         return FALSE;
     }
 
-    private function Slugify($text)
+    private function Slugify($text, $transliterate)
     {
         // replace non letter or digits by -
         $text = preg_replace('~[^\\pL\d]+~u', '-', $text);
@@ -88,7 +88,15 @@ class Slugifier
         $text = trim($text, '-');
 
         // transliterate
-        $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
+        switch ($transliterate) {
+            case 'remove':
+                $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
+                break;
+            case 'keep':
+                $text = transliterator_transliterate('Any-Latin; Latin-ASCII; [\u0100-\u7fff] remove', $text);
+                break;
+        }
+
 
         // lowercase
         $text = strtolower($text);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,11 @@ class Configuration implements ConfigurationInterface
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for
         // more information on that topic.
+        $rootNode
+            ->children()
+                ->scalarNode('transliterate')->end()
+            ->end()
+        ;
 
         return $treeBuilder;
     }

--- a/DependencyInjection/FbeenUniqueSlugExtension.php
+++ b/DependencyInjection/FbeenUniqueSlugExtension.php
@@ -24,5 +24,11 @@ class FbeenUniqueSlugExtension extends Extension
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+
+        if (array_key_exists('transliterate', $config)) {
+            $definition = $container->getDefinition('fbeen.uniqueslug.slugupdater');
+            $definition->replaceArgument(0, $config['transliterate']);
+            $container->setParameter('transliterate', $config['transliterate']);
+        }
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,6 +1,7 @@
 services:
     fbeen.uniqueslug.slugupdater:
         class: Fbeen\UniqueSlugBundle\Listener\SlugUpdater
+        arguments: ["remove"]
         tags:
             - { name: doctrine.event_listener, event: prePersist }
             - { name: doctrine.event_listener, event: preUpdate }


### PR DESCRIPTION
In order to keep some visual nice routes for languages like mine 'Romanian', please let this merge which allows to keep language specific chars by using some configuration values for your bundle:

# config.yml
parameters:
....

fbeen_unique_slug:
    #transliterate: remove # remove language specific chars
    transliterate: keep # keep language specific chars but replace them with the corresponding latin ones
....